### PR TITLE
Fix a nullreference error when an access denied message is given.

### DIFF
--- a/src/SAHB.GraphQLClient/Exceptions/GraphQLErrorException.cs
+++ b/src/SAHB.GraphQLClient/Exceptions/GraphQLErrorException.cs
@@ -28,7 +28,17 @@ namespace SAHB.GraphQLClient.Exceptions
 
             return string.Join(Environment.NewLine,
                 errors.Select(error =>
-                    $"{error.Message ?? "Error"} at {Environment.NewLine}{string.Join(Environment.NewLine, error.Locations?.Select(location => "   line: " + location.Line + " column: " + location.Column))}"));
+                    $"{error.Message ?? "Error"} at {Environment.NewLine}{GetErrorLocation(error)}"));
+        }
+
+        private static string GetErrorLocation(GraphQLDataError error)
+        {
+            var errors = (error.Locations?.Select(location => "   line: " + location?.Line + " column: " + location?.Column));
+            if (errors != null && errors.Any())
+            {
+                return string.Join(Environment.NewLine, errors);
+            }
+            return "Unknown location";
         }
 
         public IEnumerable<GraphQLDataError> Errors { get; }

--- a/tests/SAHB.GraphQLClient.Tests/Exceptions/GraphQLErrorExceptionTests.cs
+++ b/tests/SAHB.GraphQLClient.Tests/Exceptions/GraphQLErrorExceptionTests.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using SAHB.GraphQLClient.Exceptions;
+using SAHB.GraphQLClient.Result;
+using Xunit;
+
+namespace SAHB.GraphQLClient.Tests.Exceptions
+{
+    
+    public class GraphQLErrorExceptionTests
+    {
+        [Fact]
+        public void Get_Message_Should_Not_Throw_Exception()
+        {
+            var errorList = new List<GraphQLDataError> { new GraphQLDataError { Message = "Access denied." } };
+
+            new GraphQLErrorException("query", errorList);
+        }
+    }
+}


### PR DESCRIPTION
When locations object is null the string.join gives a nullreference exception.
I've added a test and a fix to prevent this.