### PR TITLE
Expose response headers through new ExecuteDetailed method

### DIFF
--- a/src/SAHB.GraphQLClient/Batching/Internal/GraphQLBatchMerger.cs
+++ b/src/SAHB.GraphQLClient/Batching/Internal/GraphQLBatchMerger.cs
@@ -62,10 +62,10 @@ namespace SAHB.GraphQLClient.Batching.Internal
             return new GraphQLBatchQuery<T>(this, identifier);
         }
 
-        public async Task<T> GetValue<T>(string identifier) 
+        public Task<T> GetValue<T>(string identifier) 
             where T : class
         {
-            return await GetDeserializedResult<T>(identifier);
+            return GetDeserializedResult<T>(identifier);
         }
 
         public async Task<GraphQLDataDetailedResult<T>> GetDetailedValue<T>(string identifier)

--- a/src/SAHB.GraphQLClient/Batching/Internal/GraphQLBatchMerger.cs
+++ b/src/SAHB.GraphQLClient/Batching/Internal/GraphQLBatchMerger.cs
@@ -62,54 +62,17 @@ namespace SAHB.GraphQLClient.Batching.Internal
             return new GraphQLBatchQuery<T>(this, identifier);
         }
 
-        public async Task<T> GetValue<T>(string identitifer) 
+        public async Task<T> GetValue<T>(string identifier) 
             where T : class
         {
-            if (!_isExecuted)
-                await Execute().ConfigureAwait(false);
-            
-            if (_result.ContainsErrors)
-            {
-                throw new GraphQLErrorException(query: _executedQuery , errors: _result.Errors);
-            }
-            
-            // Create new JObject
-            JObject deserilizeFrom = new JObject();
-
-            // Get all fields
-            foreach (var field in _fields[identitifer])
-            {
-                // Add field with previous alias to JObject
-                deserilizeFrom.Add(field.Inner.Alias, _result.Data[field.Alias]);
-            }
-
-            // Deserialize from
-            return deserilizeFrom.ToObject<T>();
+            return await GetDeserializedResult<T>(identifier);
         }
 
-        public async Task<GraphQLDataDetailedResult<T>> GetDetailedValue<T>(string identitifer)
+        public async Task<GraphQLDataDetailedResult<T>> GetDetailedValue<T>(string identifier)
             where T : class
         {
-            if (!_isExecuted)
-                await Execute().ConfigureAwait(false);
+            var deserialized = await GetDeserializedResult<T>(identifier);
 
-            if (_result.ContainsErrors)
-            {
-                throw new GraphQLErrorException(query: _executedQuery, errors: _result.Errors);
-            }
-
-            // Create new JObject
-            JObject deserilizeFrom = new JObject();
-
-            // Get all fields
-            foreach (var field in _fields[identitifer])
-            {
-                // Add field with previous alias to JObject
-                deserilizeFrom.Add(field.Inner.Alias, _result.Data[field.Alias]);
-            }
-
-            // Deserialize from
-            var deserialized = deserilizeFrom.ToObject<T>();
             return new GraphQLDataDetailedResult<T>
             {
                 Data = deserialized,
@@ -170,6 +133,30 @@ namespace SAHB.GraphQLClient.Batching.Internal
                     argument.VariableName = argumentsWithIdentitfier.Key + "_" +  argument.VariableName;
                 }
             }
+        }
+
+        private async Task<T> GetDeserializedResult<T>(string identifier)
+        {
+            if (!_isExecuted)
+                await Execute().ConfigureAwait(false);
+
+            if (_result.ContainsErrors)
+            {
+                throw new GraphQLErrorException(query: _executedQuery, errors: _result.Errors);
+            }
+
+            // Create new JObject
+            JObject deserilizeFrom = new JObject();
+
+            // Get all fields
+            foreach (var field in _fields[identifier])
+            {
+                // Add field with previous alias to JObject
+                deserilizeFrom.Add(field.Inner.Alias, _result.Data[field.Alias]);
+            }
+
+            // Deserialize from
+            return deserilizeFrom.ToObject<T>();
         }
 
         public bool Executed => _isExecuted;

--- a/src/SAHB.GraphQLClient/Batching/Internal/GraphQLBatchQuery.cs
+++ b/src/SAHB.GraphQLClient/Batching/Internal/GraphQLBatchQuery.cs
@@ -1,9 +1,8 @@
 ﻿using System.Threading.Tasks;
+using SAHB.GraphQLClient.Result;
 
 namespace SAHB.GraphQLClient.Batching.Internal
 {
-    using Result;
-
     // ReSharper disable once InconsistentNaming
     /// <inheritdoc />
     internal class GraphQLBatchQuery<T> : IGraphQLQuery<T>

--- a/src/SAHB.GraphQLClient/Batching/Internal/GraphQLBatchQuery.cs
+++ b/src/SAHB.GraphQLClient/Batching/Internal/GraphQLBatchQuery.cs
@@ -2,6 +2,8 @@
 
 namespace SAHB.GraphQLClient.Batching.Internal
 {
+    using Result;
+
     // ReSharper disable once InconsistentNaming
     /// <inheritdoc />
     internal class GraphQLBatchQuery<T> : IGraphQLQuery<T>
@@ -20,6 +22,11 @@ namespace SAHB.GraphQLClient.Batching.Internal
         public Task<T> Execute()
         {
             return _batch.GetValue<T>(_identitifer);
+        }
+
+        public Task<GraphQLDataDetailedResult<T>> ExecuteDetailed()
+        {
+            return _batch.GetDetailedValue<T>(_identitifer);
         }
     }
 }

--- a/src/SAHB.GraphQLClient/Executor/GraphQLHttpExecutor.cs
+++ b/src/SAHB.GraphQLClient/Executor/GraphQLHttpExecutor.cs
@@ -67,10 +67,10 @@ namespace SAHB.GraphQLClient.Executor
                 }
                 catch (Exception ex)
                 {
-                    throw new GraphQLHttpExecutorServerErrorStatusCodeException(response.StatusCode, query, errorResponse, "Response from server was not successfully", ex);
+                    throw new GraphQLHttpExecutorServerErrorStatusCodeException(response.StatusCode, query, errorResponse, "Response from server was not successful", ex);
                 }
 
-                throw new GraphQLHttpExecutorServerErrorStatusCodeException(response.StatusCode, query, errorResponse, "Response from server was not successfully");
+                throw new GraphQLHttpExecutorServerErrorStatusCodeException(response.StatusCode, query, errorResponse, "Response from server was not successful");
             }
 
             // Get response
@@ -85,6 +85,8 @@ namespace SAHB.GraphQLClient.Executor
             // Deserialize response
             var result = JsonConvert.DeserializeObject<GraphQLDataResult<T>>(stringResponse);
 
+            result.Headers = response.Headers;
+
             // Logging errors
             if (result.ContainsErrors && Logger != null && Logger.IsEnabled(LogLevel.Error))
             {
@@ -93,7 +95,7 @@ namespace SAHB.GraphQLClient.Executor
 
             return result;
         }
-        
+
         #region Logging
 
         private ILoggerFactory _loggerFactory;

--- a/src/SAHB.GraphQLClient/IGraphQLQuery.cs
+++ b/src/SAHB.GraphQLClient/IGraphQLQuery.cs
@@ -1,9 +1,8 @@
 ﻿using System.Threading.Tasks;
+using SAHB.GraphQLClient.Result;
 
 namespace SAHB.GraphQLClient
 {
-    using Result;
-
     // ReSharper disable once InconsistentNaming
     /// <summary>
     /// Generated Query which supports executing the query

--- a/src/SAHB.GraphQLClient/IGraphQLQuery.cs
+++ b/src/SAHB.GraphQLClient/IGraphQLQuery.cs
@@ -2,6 +2,8 @@
 
 namespace SAHB.GraphQLClient
 {
+    using Result;
+
     // ReSharper disable once InconsistentNaming
     /// <summary>
     /// Generated Query which supports executing the query
@@ -12,6 +14,11 @@ namespace SAHB.GraphQLClient
         /// Execute the query
         /// </summary>
         Task<dynamic> Execute();
+
+        /// <summary>
+        /// Execute query and return the result with response headers
+        /// </summary>
+        Task<GraphQLDataDetailedResult<dynamic>> ExecuteDetailed();
     }
 
     // ReSharper disable once InconsistentNaming
@@ -27,5 +34,11 @@ namespace SAHB.GraphQLClient
         /// </summary>
         /// <returns>The result of the query</returns>
         Task<T> Execute();
+
+        /// <summary>
+        /// Execute query and return the result with response headers
+        /// </summary>
+        /// <returns>Object containing query result and response headers</returns>
+        Task<GraphQLDataDetailedResult<T>> ExecuteDetailed();
     }
 }

--- a/src/SAHB.GraphQLClient/Internal/GraphQLQuery.cs
+++ b/src/SAHB.GraphQLClient/Internal/GraphQLQuery.cs
@@ -7,6 +7,8 @@ using SAHB.GraphQLClient.Executor;
 
 namespace SAHB.GraphQLClient.Internal
 {
+    using Result;
+
     // ReSharper disable once InconsistentNaming
     /// <inheritdoc />
     internal class GraphQLQuery : IGraphQLQuery
@@ -31,11 +33,27 @@ namespace SAHB.GraphQLClient.Internal
         /// <inheritdoc />
         public async Task<dynamic> Execute()
         {
+            var result = await GetDataResult();
+            return result?.Data;
+        }
+
+        public async Task<GraphQLDataDetailedResult<dynamic>> ExecuteDetailed()
+        {
+            var result = await GetDataResult();
+            return new GraphQLDataDetailedResult<dynamic>
+            {
+                Data = result.Data,
+                Headers = result.Headers
+            };
+        }
+
+        private async Task<GraphQLDataResult<dynamic>> GetDataResult()
+        {
             var result = await _executor.ExecuteQuery<dynamic>(_query, _url, _httpMethod, _authorizationToken, _authorizationMethod).ConfigureAwait(false);
             if (result?.Errors?.Any() ?? false)
                 throw new GraphQLErrorException(query: _query, errors: result.Errors);
 
-            return result?.Data;
+            return result;
         }
     }
 
@@ -63,11 +81,27 @@ namespace SAHB.GraphQLClient.Internal
         /// <inheritdoc />
         public async Task<T> Execute()
         {
+            var result = await GetDataResult();
+            return result?.Data;
+        }
+
+        public async Task<GraphQLDataDetailedResult<T>> ExecuteDetailed()
+        {
+            var result = await GetDataResult();
+            return new GraphQLDataDetailedResult<T>
+            {
+                Data = result.Data,
+                Headers = result.Headers
+            };
+        }
+
+        private async Task<GraphQLDataResult<T>> GetDataResult()
+        {
             var result = await _executor.ExecuteQuery<T>(_query, _url, _httpMethod, _authorizationToken, _authorizationMethod).ConfigureAwait(false);
             if (result?.Errors?.Any() ?? false)
                 throw new GraphQLErrorException(query: _query, errors: result.Errors);
 
-            return result?.Data;
+            return result;
         }
     }
 }

--- a/src/SAHB.GraphQLClient/Internal/GraphQLQuery.cs
+++ b/src/SAHB.GraphQLClient/Internal/GraphQLQuery.cs
@@ -4,11 +4,10 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using SAHB.GraphQLClient.Exceptions;
 using SAHB.GraphQLClient.Executor;
+using SAHB.GraphQLClient.Result;
 
 namespace SAHB.GraphQLClient.Internal
 {
-    using Result;
-
     // ReSharper disable once InconsistentNaming
     /// <inheritdoc />
     internal class GraphQLQuery : IGraphQLQuery

--- a/src/SAHB.GraphQLClient/Result/GraphQLDataDetailedResult.cs
+++ b/src/SAHB.GraphQLClient/Result/GraphQLDataDetailedResult.cs
@@ -1,7 +1,7 @@
-﻿namespace SAHB.GraphQLClient.Result
-{
-    using System.Net.Http.Headers;
+﻿using System.Net.Http.Headers;
 
+namespace SAHB.GraphQLClient.Result
+{
     // ReSharper disable once InconsistentNaming
     /// <summary>
     /// Contains the GraphQL data result with response headers

--- a/src/SAHB.GraphQLClient/Result/GraphQLDataDetailedResult.cs
+++ b/src/SAHB.GraphQLClient/Result/GraphQLDataDetailedResult.cs
@@ -1,0 +1,22 @@
+﻿namespace SAHB.GraphQLClient.Result
+{
+    using System.Net.Http.Headers;
+
+    // ReSharper disable once InconsistentNaming
+    /// <summary>
+    /// Contains the GraphQL data result with response headers
+    /// </summary>
+    /// <typeparam name="T">The data type returned</typeparam>
+    public class GraphQLDataDetailedResult<T>
+    {
+        /// <summary>
+        /// Contains the output from the GraphQL server. This is null, when errors has occured
+        /// </summary>
+        public T Data { get; set; }
+
+        /// <summary>
+        /// Contains the response headers
+        /// </summary>
+        public HttpResponseHeaders Headers { get; set; }
+    }
+}

--- a/src/SAHB.GraphQLClient/Result/GraphQLDataResult.cs
+++ b/src/SAHB.GraphQLClient/Result/GraphQLDataResult.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http.Headers;
 
 namespace SAHB.GraphQLClient.Result
 {
-    using System.Net.Http.Headers;
-
     // ReSharper disable once InconsistentNaming
     /// <summary>
     /// Contains the GraphQL data result

--- a/src/SAHB.GraphQLClient/Result/GraphQLDataResult.cs
+++ b/src/SAHB.GraphQLClient/Result/GraphQLDataResult.cs
@@ -3,6 +3,8 @@ using System.Linq;
 
 namespace SAHB.GraphQLClient.Result
 {
+    using System.Net.Http.Headers;
+
     // ReSharper disable once InconsistentNaming
     /// <summary>
     /// Contains the GraphQL data result
@@ -14,6 +16,11 @@ namespace SAHB.GraphQLClient.Result
         /// Contains the output from the GraphQL server. This is null, when errors has occured
         /// </summary>
         public T Data { get; set; }
+
+        /// <summary>
+        /// Contains the response headers
+        /// </summary>
+        public HttpResponseHeaders Headers { get; set; }
 
         /// <summary>
         /// The errors which occured on execution of the query

--- a/tests/SAHB.GraphQLClient.Tests/Batching/BatchingTest.cs
+++ b/tests/SAHB.GraphQLClient.Tests/Batching/BatchingTest.cs
@@ -12,6 +12,9 @@ using Xunit;
 
 namespace SAHB.GraphQLClient.Tests.Batching
 {
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+
     public class BatchingTest
     {
         [Fact]
@@ -265,6 +268,55 @@ namespace SAHB.GraphQLClient.Tests.Batching
             // Assert
             Assert.Equal(result1.Part1Field1, result2.Part1Field1);
             Assert.Equal(result1.Part1Field2, result2.Part1Field2);
+        }
+
+        [Fact]
+        public async Task Test_ExecuteDetailed_Returns_Expected_Headers_And_Data()
+        {
+            // Arrange
+            var requiredQuery =
+                "{\"query\":\"query{batch0_Part1Field1:part1_field1 batch0_Part1Field2:part1Field2 batch1_Part2Field3:part2_field3 batch1_Part2Field4:part2Field4}\"}";
+            var requiredHeaders = new HttpResponseMessage().Headers;
+            requiredHeaders.Add("TestHeader", "TestValue");
+
+            var httpClientMock = new GraphQLHttpExecutorMock(
+                JsonConvert.SerializeObject(new
+                {
+                    Data = new
+                    {
+                        batch0_Part1Field1 = "Value1",
+                        batch0_Part1Field2 = "Value2",
+                        batch1_Part2Field3 = "Value3",
+                        batch1_Part2Field4 = "Value4"
+                    }
+                }), requiredQuery, requiredHeaders);
+            var client = new GraphQLHttpClient(httpClientMock, new GraphQLFieldBuilder(),
+                new GraphQLQueryGeneratorFromFields());
+
+            // Act
+            var batch = client.CreateBatch("");
+            var query1 = batch.Query<QueryBatchPart1>();
+            var query2 = batch.Query<QueryBatchPart2>();
+
+            var result1 = await query1.ExecuteDetailed();
+            var result2 = await query2.ExecuteDetailed();
+
+            // Assert
+            Assert.Equal(result1.Data.Part1Field1, "Value1");
+            Assert.Equal(result1.Data.Part1Field2, "Value2");
+
+            Assert.Equal(result2.Data.Part2Field3, "Value3");
+            Assert.Equal(result2.Data.Part2Field4, "Value4");
+
+            IEnumerable<string> expectedHeaders = new List<string>();
+            IEnumerable<string> actualHeaders = new List<string>();
+            requiredHeaders.TryGetValues("TestHeader", out expectedHeaders);
+            result1.Headers.TryGetValues("TestHeader", out actualHeaders);
+            Assert.Equal(actualHeaders, expectedHeaders);
+
+            requiredHeaders.TryGetValues("TestHeader", out expectedHeaders);
+            result2.Headers.TryGetValues("TestHeader", out actualHeaders);
+            Assert.Equal(actualHeaders, expectedHeaders);
         }
     }
 }

--- a/tests/SAHB.GraphQLClient.Tests/Batching/BatchingTest.cs
+++ b/tests/SAHB.GraphQLClient.Tests/Batching/BatchingTest.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using SAHB.GraphQLClient.Exceptions;
@@ -9,12 +7,10 @@ using SAHB.GraphQLClient.FieldBuilder.Attributes;
 using SAHB.GraphQLClient.QueryGenerator;
 using SAHB.GraphQLClient.Tests.GraphQLClient.HttpClientMock;
 using Xunit;
+using System.Net.Http;
 
 namespace SAHB.GraphQLClient.Tests.Batching
 {
-    using System.Net.Http;
-    using System.Net.Http.Headers;
-
     public class BatchingTest
     {
         [Fact]

--- a/tests/SAHB.GraphQLClient.Tests/Mocks/HttpClientMock/GraphQLHttpExecutorMock.cs
+++ b/tests/SAHB.GraphQLClient.Tests/Mocks/HttpClientMock/GraphQLHttpExecutorMock.cs
@@ -11,15 +11,24 @@ using Xunit;
 
 namespace SAHB.GraphQLClient.Tests.GraphQLClient.HttpClientMock
 {
+    using System.Net.Http.Headers;
+
     public class GraphQLHttpExecutorMock : IGraphQLHttpExecutor
     {
         private readonly string _requiredQuery;
+        private readonly HttpResponseHeaders _requiredHeaders;
         private readonly string _response;
 
-        public GraphQLHttpExecutorMock(string response, string requiredQuery)
+        public GraphQLHttpExecutorMock(string response, string requiredQuery, HttpResponseHeaders requiredHeaders)
         {
             _requiredQuery = requiredQuery;
+            _requiredHeaders = requiredHeaders;
             _response = response;
+        }
+
+        public GraphQLHttpExecutorMock(string response, string requiredQuery) : this(response, requiredQuery, null)
+        {
+
         }
 
         public HttpRequestMessage LastRequest { get; private set; }
@@ -30,7 +39,10 @@ namespace SAHB.GraphQLClient.Tests.GraphQLClient.HttpClientMock
             // Check if query is correct
             Assert.Equal(_requiredQuery, query);
 
-            return Task.FromResult(JsonConvert.DeserializeObject<GraphQLDataResult<T>>(_response));
+            var result = JsonConvert.DeserializeObject<GraphQLDataResult<T>>(_response);
+            result.Headers = _requiredHeaders;
+
+            return Task.FromResult(result);
         }
     }
 }

--- a/tests/SAHB.GraphQLClient.Tests/Mocks/HttpClientMock/GraphQLHttpExecutorMock.cs
+++ b/tests/SAHB.GraphQLClient.Tests/Mocks/HttpClientMock/GraphQLHttpExecutorMock.cs
@@ -1,18 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Net.Http;
-using System.Text;
+﻿using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using SAHB.GraphQLClient.Executor;
 using SAHB.GraphQLClient.Result;
 using Xunit;
+using System.Net.Http.Headers;
 
 namespace SAHB.GraphQLClient.Tests.GraphQLClient.HttpClientMock
 {
-    using System.Net.Http.Headers;
-
     public class GraphQLHttpExecutorMock : IGraphQLHttpExecutor
     {
         private readonly string _requiredQuery;

--- a/tests/SAHB.GraphQLClient.Tests/Mocks/HttpClientMock/GraphQLHttpExecutorMock.cs
+++ b/tests/SAHB.GraphQLClient.Tests/Mocks/HttpClientMock/GraphQLHttpExecutorMock.cs
@@ -14,16 +14,15 @@ namespace SAHB.GraphQLClient.Tests.GraphQLClient.HttpClientMock
         private readonly HttpResponseHeaders _requiredHeaders;
         private readonly string _response;
 
-        public GraphQLHttpExecutorMock(string response, string requiredQuery, HttpResponseHeaders requiredHeaders)
+        public GraphQLHttpExecutorMock(string response, string requiredQuery)
         {
             _requiredQuery = requiredQuery;
-            _requiredHeaders = requiredHeaders;
             _response = response;
         }
 
-        public GraphQLHttpExecutorMock(string response, string requiredQuery) : this(response, requiredQuery, null)
+        public GraphQLHttpExecutorMock(string response, string requiredQuery, HttpResponseHeaders requiredHeaders) : this(response, requiredQuery)
         {
-
+            _requiredHeaders = requiredHeaders;
         }
 
         public HttpRequestMessage LastRequest { get; private set; }


### PR DESCRIPTION
Hi, great library, I'm using it in a personal project and I've come across a missing feature I'd like to add.

I'm using the http://anilist.co API, docs here https://anilist.gitbook.io/anilist-apiv2-docs/

Their API returns some useful headers in the response so you can see your rate limit and remaining requests. I'm sure there's other APIs that also do this too.

I've been experimenting with different ways of exposing this in your library and I've come up with the following solution. I think it's the most elegant way of exposing the headers without making breaking changes.

Let me know what you think!

Cheers