### PR TITLE
Added the ability to pass a payload to the initialization phase...

### DIFF
--- a/src/SAHB.GraphQL.Client.Subscription/GraphQLSubscriptionClient.cs
+++ b/src/SAHB.GraphQL.Client.Subscription/GraphQLSubscriptionClient.cs
@@ -59,16 +59,18 @@ namespace SAHB.GraphQLClient.Subscription
         public bool IsInitilized { get; private set; }
 
         /// <inheritdoc />
-        public async Task Initilize()
+        public async Task Initilize(object payload = null)
         {
             if (!IsConnected)
                 throw new InvalidOperationException("Connection is not open");
 
+            if (payload == null)
+                payload = new object();
             // Sent GQL_CONNECTION_INIT
             await SendOperationMessage(new OperationMessage
             {
                 Type = MessageType.GQL_CONNECTION_INIT,
-                Payload = new object()
+                Payload = payload
             }).ConfigureAwait(false);
 
             // Wait for ack

--- a/src/SAHB.GraphQL.Client.Subscription/IGraphQLSubscriptionClient.cs
+++ b/src/SAHB.GraphQL.Client.Subscription/IGraphQLSubscriptionClient.cs
@@ -14,7 +14,7 @@ namespace SAHB.GraphQLClient.Subscription
         /// Initilizes the GraphQL subscription connection
         /// </summary>
         /// <returns></returns>
-        Task Initilize();
+        Task Initilize(object payload = null);
 
         /// <summary>
         /// Returns true if the websocket is connected


### PR DESCRIPTION
…and thereby enabling authenticated ws endpoints.

We needed this after enabling authenticated subscriptions and this fix/feature is hopefully pretty non-obtrusive.

Example usage:
``` c#
var graphQLSubscriptionClient = await graphQLSubscriptionWebsocketClient.Connect(_subscriptionUrl);
var authPayload = new { Authorization = "Bearer " + _token };
await graphQLSubscriptionClient.Initilize(authPayload);
```